### PR TITLE
[KW-658] refactor: 출입 로그  grpc 레디스 스트림에 저장하도록 수정

### DIFF
--- a/src/main/java/com/doubleo/logservice/domain/log/consumer/AreaEnterLogConsumer.java
+++ b/src/main/java/com/doubleo/logservice/domain/log/consumer/AreaEnterLogConsumer.java
@@ -40,7 +40,7 @@ public class AreaEnterLogConsumer {
         }
     }
 
-    @Scheduled(fixedDelay = 300000)
+    @Scheduled(fixedDelay = 10000)
     public void consumeMessages() {
         List<MapRecord<String, Object, Object>> messages =
                 redisTemplate

--- a/src/main/java/com/doubleo/logservice/domain/log/consumer/BuildingEnterLogConsumer.java
+++ b/src/main/java/com/doubleo/logservice/domain/log/consumer/BuildingEnterLogConsumer.java
@@ -41,7 +41,7 @@ public class BuildingEnterLogConsumer {
         }
     }
 
-    @Scheduled(fixedDelay = 300000)
+    @Scheduled(fixedDelay = 10000)
     public void consumeMessages() {
         List<MapRecord<String, Object, Object>> messages =
                 redisTemplate

--- a/src/main/java/com/doubleo/logservice/domain/log/consumer/RetainedCountConsumer.java
+++ b/src/main/java/com/doubleo/logservice/domain/log/consumer/RetainedCountConsumer.java
@@ -34,7 +34,7 @@ public class RetainedCountConsumer {
         }
     }
 
-    @Scheduled(fixedDelay = 300000)
+    @Scheduled(fixedDelay = 10000)
     public void consume() {
         List<MapRecord<String, Object, Object>> records =
                 redisTemplate

--- a/src/main/java/com/doubleo/logservice/domain/log/dto/request/CreateAreaEnterLogRequest.java
+++ b/src/main/java/com/doubleo/logservice/domain/log/dto/request/CreateAreaEnterLogRequest.java
@@ -1,4 +1,6 @@
 package com.doubleo.logservice.domain.log.dto.request;
 
+import com.doubleo.logservice.global.enums.VisitCategory;
+
 public record CreateAreaEnterLogRequest(
-        String tenantId, Long areaId, Long memberId, String memberName, Long passId) {}
+        String tenantId, Long areaId, Long memberId, String memberName, Long passId, VisitCategory visitCategory) {}

--- a/src/main/java/com/doubleo/logservice/domain/log/dto/request/CreateAreaEnterLogRequest.java
+++ b/src/main/java/com/doubleo/logservice/domain/log/dto/request/CreateAreaEnterLogRequest.java
@@ -3,4 +3,9 @@ package com.doubleo.logservice.domain.log.dto.request;
 import com.doubleo.logservice.global.enums.VisitCategory;
 
 public record CreateAreaEnterLogRequest(
-        String tenantId, Long areaId, Long memberId, String memberName, Long passId, VisitCategory visitCategory) {}
+        String tenantId,
+        Long areaId,
+        Long memberId,
+        String memberName,
+        Long passId,
+        VisitCategory visitCategory) {}

--- a/src/main/java/com/doubleo/logservice/domain/log/producer/AreaEnterLogStreamProducer.java
+++ b/src/main/java/com/doubleo/logservice/domain/log/producer/AreaEnterLogStreamProducer.java
@@ -21,6 +21,7 @@ public class AreaEnterLogStreamProducer {
         message.put("memberId", request.memberId().toString());
         message.put("memberName", request.memberName());
         message.put("passId", request.passId().toString());
+        message.put("visitCategory", request.visitCategory().name());
         message.put("timestamp", LocalDateTime.now().toString());
 
         redisTemplate.opsForStream().add("area:enter:stream", message);

--- a/src/main/java/com/doubleo/logservice/grpc/server/LogGrpcServiceImpl.java
+++ b/src/main/java/com/doubleo/logservice/grpc/server/LogGrpcServiceImpl.java
@@ -1,6 +1,8 @@
 package com.doubleo.logservice.grpc.server;
 
 import com.doubleo.logservice.domain.log.domain.*;
+import com.doubleo.logservice.domain.log.producer.AreaEnterLogStreamProducer;
+import com.doubleo.logservice.domain.log.producer.BuildingEnterLogStreamProducer;
 import com.doubleo.logservice.domain.log.repository.BuildingEnterLogRepository;
 import com.doubleo.logservice.domain.log.repository.EnterLogRepository;
 import com.doubleo.logservice.domain.log.repository.IssuedLogAreaRepository;
@@ -18,16 +20,22 @@ public class LogGrpcServiceImpl extends LogServiceGrpc.LogServiceImplBase {
     private final IssuedLogAreaRepository issuedLogAreaRepository;
     private final EnterLogRepository enterLogRepository;
     private final BuildingEnterLogRepository buildingEnterLogRepository;
+    private final AreaEnterLogStreamProducer areaEnterLogProducer;
+    private final BuildingEnterLogStreamProducer buildingEnterLogProducer;
+
 
     public LogGrpcServiceImpl(
             IssuedLogRepository issuedLogRepository,
             IssuedLogAreaRepository issuedLogAreaRepository,
             EnterLogRepository enterLogRepository,
-            BuildingEnterLogRepository buildingEnterLogRepository) {
+            BuildingEnterLogRepository buildingEnterLogRepository, AreaEnterLogStreamProducer areaProducer, BuildingEnterLogStreamProducer buildingEnterLogProducer) {
         this.issuedLogRepository = issuedLogRepository;
         this.issuedLogAreaRepository = issuedLogAreaRepository;
         this.enterLogRepository = enterLogRepository;
         this.buildingEnterLogRepository = buildingEnterLogRepository;
+        this.areaEnterLogProducer = areaProducer;
+
+        this.buildingEnterLogProducer = buildingEnterLogProducer;
     }
 
     @Override
@@ -62,17 +70,20 @@ public class LogGrpcServiceImpl extends LogServiceGrpc.LogServiceImplBase {
     public void createEnterLog(
             CreateEnterLogRequest request,
             StreamObserver<CreateEnterLogResponse> responseObserver) {
-        EnterLog enterLog =
-                enterLogRepository.save(
-                        EnterLog.createEnterLog(
-                                request.getTenantId(),
-                                request.getAreaId(),
-                                request.getMemberId(),
-                                request.getMemberName(),
-                                request.getPassId(),
-                                VisitCategory.valueOf(request.getVisitCategory())));
+        areaEnterLogProducer.sendAreaEnterLogToStream(
+                new com.doubleo.logservice.domain.log.dto.request.CreateAreaEnterLogRequest(
+                        request.getTenantId(),
+                        request.getAreaId(),
+                        request.getMemberId(),
+                        request.getMemberName(),
+                        request.getPassId(),
+                        VisitCategory.valueOf(request.getVisitCategory())
+                )
+        );
+
         responseObserver.onNext(
-                CreateEnterLogResponse.newBuilder().setEnterLogId(enterLog.getId()).build());
+                CreateEnterLogResponse.newBuilder().setEnterLogId(1L).build()
+        );
         responseObserver.onCompleted();
     }
 
@@ -80,20 +91,23 @@ public class LogGrpcServiceImpl extends LogServiceGrpc.LogServiceImplBase {
     public void createBuildingEnterLog(
             CreateBuildingEnterLogRequest request,
             StreamObserver<CreateBuildingEnterLogResponse> responseObserver) {
-        BuildingEnterLog buildingEnterLog =
-                buildingEnterLogRepository.save(
-                        BuildingEnterLog.createBuildingEnterLog(
-                                request.getTenantId(),
-                                request.getBuildingId(),
-                                request.getMemberId(),
-                                request.getMemberName(),
-                                request.getPassId(),
-                                Direction.valueOf(request.getDirection()),
-                                VisitCategory.valueOf(request.getVisitCategory())));
+        buildingEnterLogProducer.sendBuildingEnterLogToStream(
+                new com.doubleo.logservice.domain.log.dto.request.CreateBuildingEnterLogRequest(
+                        request.getTenantId(),
+                        request.getBuildingId(),
+                        request.getMemberId(),
+                        request.getMemberName(),
+                        request.getPassId(),
+                        Direction.valueOf(request.getDirection()),
+                        VisitCategory.valueOf(request.getVisitCategory())
+                )
+        );
+
         responseObserver.onNext(
                 CreateBuildingEnterLogResponse.newBuilder()
-                        .setBuildingEnterLogId(buildingEnterLog.getId())
-                        .build());
+                        .setBuildingEnterLogId(1L)
+                        .build()
+        );
         responseObserver.onCompleted();
     }
 }

--- a/src/main/java/com/doubleo/logservice/grpc/server/LogGrpcServiceImpl.java
+++ b/src/main/java/com/doubleo/logservice/grpc/server/LogGrpcServiceImpl.java
@@ -23,12 +23,13 @@ public class LogGrpcServiceImpl extends LogServiceGrpc.LogServiceImplBase {
     private final AreaEnterLogStreamProducer areaEnterLogProducer;
     private final BuildingEnterLogStreamProducer buildingEnterLogProducer;
 
-
     public LogGrpcServiceImpl(
             IssuedLogRepository issuedLogRepository,
             IssuedLogAreaRepository issuedLogAreaRepository,
             EnterLogRepository enterLogRepository,
-            BuildingEnterLogRepository buildingEnterLogRepository, AreaEnterLogStreamProducer areaProducer, BuildingEnterLogStreamProducer buildingEnterLogProducer) {
+            BuildingEnterLogRepository buildingEnterLogRepository,
+            AreaEnterLogStreamProducer areaProducer,
+            BuildingEnterLogStreamProducer buildingEnterLogProducer) {
         this.issuedLogRepository = issuedLogRepository;
         this.issuedLogAreaRepository = issuedLogAreaRepository;
         this.enterLogRepository = enterLogRepository;
@@ -77,13 +78,9 @@ public class LogGrpcServiceImpl extends LogServiceGrpc.LogServiceImplBase {
                         request.getMemberId(),
                         request.getMemberName(),
                         request.getPassId(),
-                        VisitCategory.valueOf(request.getVisitCategory())
-                )
-        );
+                        VisitCategory.valueOf(request.getVisitCategory())));
 
-        responseObserver.onNext(
-                CreateEnterLogResponse.newBuilder().setEnterLogId(1L).build()
-        );
+        responseObserver.onNext(CreateEnterLogResponse.newBuilder().setEnterLogId(1L).build());
         responseObserver.onCompleted();
     }
 
@@ -99,15 +96,10 @@ public class LogGrpcServiceImpl extends LogServiceGrpc.LogServiceImplBase {
                         request.getMemberName(),
                         request.getPassId(),
                         Direction.valueOf(request.getDirection()),
-                        VisitCategory.valueOf(request.getVisitCategory())
-                )
-        );
+                        VisitCategory.valueOf(request.getVisitCategory())));
 
         responseObserver.onNext(
-                CreateBuildingEnterLogResponse.newBuilder()
-                        .setBuildingEnterLogId(1L)
-                        .build()
-        );
+                CreateBuildingEnterLogResponse.newBuilder().setBuildingEnterLogId(1L).build());
         responseObserver.onCompleted();
     }
 }


### PR DESCRIPTION
## 🔷 Jira Ticket ID

[KW-658]

---
## 📌 작업 내용 및 특이사항

- 기존에 바로 DB에 저장하던 출입 로그 생성 방식을 gRPC 요청을 통해 Redis Stream으로 전송하는 방식으로 변경
- response의 1L은 정상적으로 로그 전송이 완료되었음을 의미하는 더미 ID로 사용함
- 테스트를 위해서 스케줄링 10초로 변경

---
## 📚 참고사항

-


[KW-658]: https://teamdoubleo.atlassian.net/browse/KW-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ